### PR TITLE
Support for assembly files compilation (.s)

### DIFF
--- a/cmake/ArduinoToolchain.cmake
+++ b/cmake/ArduinoToolchain.cmake
@@ -9,6 +9,7 @@
 set(CMAKE_SYSTEM_NAME Arduino)
 
 set(CMAKE_C_COMPILER   avr-gcc)
+set(CMAKE_ASM_COMPILER avr-gcc)
 set(CMAKE_CXX_COMPILER avr-g++)
 
 # Add current directory to CMake Module path automatically

--- a/cmake/Platform/Arduino.cmake
+++ b/cmake/Platform/Arduino.cmake
@@ -1854,6 +1854,8 @@ function(find_sources VAR_NAME LIB_PATH RECURSE)
     set(FILE_SEARCH_LIST
             ${LIB_PATH}/*.cpp
             ${LIB_PATH}/*.c
+            ${LIB_PATH}/*.s
+            ${LIB_PATH}/*.S
             ${LIB_PATH}/*.cc
             ${LIB_PATH}/*.cxx
             ${LIB_PATH}/*.h


### PR DESCRIPTION
Fist of all, thank you and congratulations for your work on this repo. I found myself using this fork instead of the original repo because this seems to be actually active and mantained.

I found this issue when trying to use the arduino library [AESLib](https://github.com/DavyLandman/AESLib), which falied when compiling complaining about functions not defined. Said functions were implemented on assembler code on its own files (.S extension). This patch allows said libs to work.